### PR TITLE
docs: update API specs to match current backend behavior

### DIFF
--- a/src/api-specification/contribution-controller/assembling-a-contribution.md
+++ b/src/api-specification/contribution-controller/assembling-a-contribution.md
@@ -59,7 +59,7 @@ For a detailed breakdown of every field and value in the body of a request, see 
 
 ::: tip NOTE
 
-This endpoint accepts requests with up to `500` entries.
+This endpoint accepts requests with up to `5000` entries.
 
 :::
 

--- a/src/api-specification/contribution-controller/retrieving-contributions.md
+++ b/src/api-specification/contribution-controller/retrieving-contributions.md
@@ -19,7 +19,7 @@ The following parameters can be specified with the request to filter the retriev
 
 | Field | Value Type | Description |
 | :-: | --- | --- |
-| `size` | `integer($int32)` | The number of entries, starting with the latest, shown in the response. <br> Set to `50` by default. |
+| `size` | `integer($int32)` | The number of entries, starting with the latest, shown in the response. <br> If not specified, all available contributions are returned. |
 | `from` and `to` | `string` | The timeframe that the response entries are filtered by. Both are set as an exact time and date (ISO 8601: `YYYY-MM-DDTHH:MM:SSZ`). <br> If the `from` parameter is left unspecified, the results will be fetched since the establishment of the FIB network. <br> If the `to` parameter is left unspecified, the results will be fetched until the latest uploaded contribution. |
 | `ft` | `array[string]` | The [type of the fraud event](../../overview/fraud-events.md#types-of-fraud-events). <br> Can be one of the following: <ol><li>`Wangiri`</li><li>`IRSF`</li><li>`StolenDevice`</li><li>`IPFraud`</li><li>`SMSA2P`</li><li>`FlashCall`</li><li>`Scam`</li></ol> |
 | `org` | `array[string]` | The country of origination of the fraud event. Set as a two-letter country code (Alpha-2, ISO 3166; e.g., US, GA). |

--- a/src/tutorials-api/retrieving-contributions.md
+++ b/src/tutorials-api/retrieving-contributions.md
@@ -19,7 +19,7 @@ To retrieve contributions, send the following request:
 ::: code-group Data structure
 
 ```http [Input structure]
-GET /api/v1/contribution-management/contribution?size=''&from=''&to=''&ft=''&org=''&self-only=''
+GET /api/v1/contribution-management/contribution?size=''&from=''&to=''&ft=''&org=''&dst=''&fetch-mode=''&confidence-score=''
 ```
 
 ```http [Input examples]
@@ -38,14 +38,14 @@ GET /api/v1/contribution-management/contribution?size=''&from=''&to=''&ft=''&org
 // dst
 /api/v1/contribution-management/contribution?dst=GA
 
-// self-only
-/api/v1/contribution-management/contribution?self-only=true
-
 // fetch-mode
-/api/v1/contribution-management/contribution?fetch-mode=new
+/api/v1/contribution-management/contribution?fetch-mode=NEW
+
+// confidence-score
+/api/v1/contribution-management/contribution?confidence-score=true
 
 // combination
-/api/v1/contribution-management/contribution?size=2&ft=StolenDevice&org=US&self-only=true&fetch-mode=new
+/api/v1/contribution-management/contribution?size=2&ft=StolenDevice&org=US&fetch-mode=NEW&confidence-score=true
 ```
 
 :::
@@ -66,7 +66,7 @@ The response to the `GET` request contains a list of the contributions, filtered
   data: {
     contributions: [
         {
-          id: 'string', //127.0.0.1 OR 127.0.0.1-127.0.0.2 OR +14155552671 OR +14155552671-+14155552672 OR 107615702016566
+          id: 'string', //127.0.0.1 OR 127.0.0.1-127.0.0.2 OR +14155552671 OR +14155552671-+14155552672 OR 107615702016566 OR address@mail.com OR https://www.address.com/
           fraudType: 'string',
           origination: 'string',
           destination: 'string',

--- a/src/tutorials-api/submitting-a-contribution.md
+++ b/src/tutorials-api/submitting-a-contribution.md
@@ -19,17 +19,11 @@ To submit a contribution, perform the following steps:
    ```json5 [Input structure]
    [
      {
-       id: 'string', //127.0.0.1 OR 127.0.0.1-127.0.0.2 OR +14155552671 OR +14155552671-+14155552672 OR 107615702016566
+       id: 'string', //127.0.0.1 OR 127.0.0.1-127.0.0.2 OR +14155552671 OR +14155552671-+14155552672 OR 107615702016566 OR address@mail.com OR https://www.address.com/
        fraudType: 'string',
        origination: 'string',
        destination: 'string',
-       expiryDate: integer($int32),
-       fraudStatus: "string(enum)", //'ACTIVE' OR 'EXPIRED' OR 'FLAGGED'
-       confidenceIndex: number($double),
-       isPrivileged: boolean,
-       peerId: 'string',
-       flagger: 'string',
-       timestamp: integer($int32)
+       sourcePeerId: 'string' // optional — registered peer identifier
      }
    ]
    ```
@@ -40,14 +34,7 @@ To submit a contribution, perform the following steps:
        id: '129.0.0.1',
        fraudType: 'IPFraud',
        origination: 'SE',
-       destination: 'GB',
-       expiryDate: 1719068894,
-       fraudStatus: 'Active',
-       confidenceIndex: 100,
-       isPrivileged: true,
-       peerId: 'wonderland',
-       flagger: 'alice@wonderland',
-       timestamp: 2024-08-30T17:07:33Z
+       destination: 'GB'
      }
    ]
    ```


### PR DESCRIPTION
- Batch contribution limit: 500 → 5000
- Size parameter default: 50 → all (no limit)
- Remove self-only param, use fetch-mode (DEFAULT/OLD/NEW/SELF)
- Add confidence-score param to retrieval examples
- Fix submit tutorial: remove response-only fields from input structure
- Add email and URL to supported fraud identifier types