### PR TITLE
docs: state the API base URL

### DIFF
--- a/src/getting-started/calling-api-endpoints.md
+++ b/src/getting-started/calling-api-endpoints.md
@@ -10,6 +10,16 @@ The API is intended for automated integrations. To upload, flag or download frau
 
 Using these credentials, you can implement calls to the FIB API endpoints into the code of your own application or system.
 
+## Base URL
+
+Send every API request to:
+
+```
+https://backend.fraudintelligencelimited.com
+```
+
+Endpoint paths throughout this documentation are relative to that host. For example, [Authorizing an account](../tutorials-api/authorizing-an-account.md) gives the path `POST /auth/api/v1/authentication-management/session`, so the full URL is `https://backend.fraudintelligencelimited.com/auth/api/v1/authentication-management/session`.
+
 Following the basic API architecture, your application or system—the _API client_ in this relationship—connects to the FIB _API server_.
 
 To integrate your API client with the FIB API server, you can use different programming languages and frameworks, including Python, Java, Node.js, RUST, depending on the requirements of your own application or system.


### PR DESCRIPTION
## Why

A PryvX engineer integrating against the API asked which base URL to use, and the documentation had no answer. Every tutorial and every API specification page gives paths only, such as `POST /auth/api/v1/authentication-management/session`, and no page states the host they hang off. The only place a host appears at all is the public test environment page.

## What changed

`getting-started/calling-api-endpoints.md` now states the base URL, `https://backend.fraudintelligencelimited.com`, and shows one worked example of joining it to a documented path.

Verified against production: a request to that host reaches the auth service and is validated. The `api.` subdomain some clients assume does not resolve.

## Noted separately, not fixed here

The public test environment page documents `app.stage1.fraudintelligencelimited.com` and `backend.stage1.fraudintelligencelimited.com`. Neither hostname resolves any more, so a reader following that page gets DNS failures. Whether to restore the environment or withdraw the page is a product decision, so this PR leaves it alone.
