### PR TITLE
docs: mark the public test environment unavailable

### DIFF
--- a/src/getting-started/public-test-environment.md
+++ b/src/getting-started/public-test-environment.md
@@ -1,5 +1,11 @@
 # Public test environment
 
+::: warning NOTE
+
+The public test environment is currently unavailable and the hostnames below do not resolve. Until it is restored, integrate against the production host given in [Calling API endpoints](./calling-api-endpoints.md#base-url).
+
+:::
+
 The test environment is a safe and controlled environment where you can try out and experiment with the FIB API without affecting the production system. Here, you can make mistakes, test different scenarios, and learn how to use the API.
 
 To access the test environment, you need to follow the same steps as for the production environment. The only difference is that you will be provided with test credentials instead of production credentials (see [Connection details](#connection-details) below).


### PR DESCRIPTION
## Why

`app.stage1.fraudintelligencelimited.com` and `backend.stage1.fraudintelligencelimited.com`, the two hosts this page hands out, no longer resolve. A reader following the page meets DNS failures with nothing explaining them.

## What changed

A warning at the top of the page states that the environment is unavailable and points to the production base URL. The connection details are left in place for when it returns.

Restoring the environment or withdrawing the page entirely is a product decision; this only stops the page misleading readers in the meantime.
